### PR TITLE
Improve the Arquillian tests in preparation for UNIONVMS-4656

### DIFF
--- a/rest/src/test/java/eu/europa/ec/fisheries/uvms/mobileterminal/rest/ConfigServiceMock.java
+++ b/rest/src/test/java/eu/europa/ec/fisheries/uvms/mobileterminal/rest/ConfigServiceMock.java
@@ -12,13 +12,13 @@ package eu.europa.ec.fisheries.uvms.mobileterminal.rest;
 
 import java.util.Arrays;
 import javax.ejb.ActivationConfigProperty;
+import javax.ejb.EJB;
 import javax.ejb.MessageDriven;
 import javax.jms.Message;
 import javax.jms.MessageListener;
 import javax.jms.TextMessage;
 import eu.europa.ec.fisheries.schema.config.types.v1.PullSettingsStatus;
 import eu.europa.ec.fisheries.schema.config.types.v1.SettingType;
-import eu.europa.ec.fisheries.uvms.commons.message.impl.AbstractProducer;
 import eu.europa.ec.fisheries.uvms.config.model.mapper.ModuleResponseMapper;
 
 @MessageDriven(mappedName = "jms/queue/UVMSConfigEvent", activationConfig = {
@@ -26,7 +26,9 @@ import eu.europa.ec.fisheries.uvms.config.model.mapper.ModuleResponseMapper;
         @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue"), 
         @ActivationConfigProperty(propertyName = "destination", propertyValue = "UVMSConfigEvent")})
 public class ConfigServiceMock implements MessageListener {
-    
+
+    @EJB
+    private MobileTerminalModuleMockProducer mobileTerminalModuleMockProducer;
     
     @Override
     public void onMessage(Message message) {
@@ -36,15 +38,10 @@ public class ConfigServiceMock implements MessageListener {
             mockSetting.setValue("Value");
             mockSetting.setDescription("From ConfigServiceMock.java");
             String response = ModuleResponseMapper.toPullSettingsResponse(Arrays.asList(mockSetting), PullSettingsStatus.OK);
-            
-            new AbstractProducer() {
-                @Override
-                public String getDestinationName() {
-                    return "jms/queue/UVMSMobileTerminal";
-                }
-            }.sendResponseMessageToSender((TextMessage) message, response);
-            
+
+            mobileTerminalModuleMockProducer.sendResponseMessageToSender((TextMessage) message, response);
         } catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/rest/src/test/java/eu/europa/ec/fisheries/uvms/mobileterminal/rest/ExchangeModuleMock.java
+++ b/rest/src/test/java/eu/europa/ec/fisheries/uvms/mobileterminal/rest/ExchangeModuleMock.java
@@ -15,10 +15,10 @@ import eu.europa.ec.fisheries.schema.exchange.service.v1.CapabilityListType;
 import eu.europa.ec.fisheries.schema.exchange.service.v1.CapabilityType;
 import eu.europa.ec.fisheries.schema.exchange.service.v1.CapabilityTypeType;
 import eu.europa.ec.fisheries.schema.exchange.service.v1.ServiceResponseType;
-import eu.europa.ec.fisheries.uvms.commons.message.impl.AbstractProducer;
 import eu.europa.ec.fisheries.uvms.mobileterminal.service.bean.mapper.ExchangeModuleResponseMapper;
 
 import javax.ejb.ActivationConfigProperty;
+import javax.ejb.EJB;
 import javax.ejb.MessageDriven;
 import javax.jms.Message;
 import javax.jms.MessageListener;
@@ -31,6 +31,9 @@ import java.util.List;
                 propertyName = "destinationType", propertyValue = "javax.jms.Queue"), @ActivationConfigProperty(
                         propertyName = "destination", propertyValue = "UVMSExchangeEvent")})
 public class ExchangeModuleMock implements MessageListener {
+
+    @EJB
+    private MobileTerminalModuleMockProducer mobileTerminalModuleMockProducer;
 
     @Override
     public void onMessage(Message message) {
@@ -50,14 +53,9 @@ public class ExchangeModuleMock implements MessageListener {
             serviceResponse.add(serviceResponseType);
             String response = ExchangeModuleResponseMapper.mapServiceListResponse(serviceResponse);
 
-            new AbstractProducer() {
-                @Override
-                public String getDestinationName() {
-                    return "jms/queue/UVMSMobileTerminal";
-                }
-            }.sendResponseMessageToSender((TextMessage) message, response);
+            mobileTerminalModuleMockProducer.sendResponseMessageToSender((TextMessage) message, response);
         } catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
-
 }

--- a/rest/src/test/java/eu/europa/ec/fisheries/uvms/mobileterminal/rest/MobileTerminalModuleMockProducer.java
+++ b/rest/src/test/java/eu/europa/ec/fisheries/uvms/mobileterminal/rest/MobileTerminalModuleMockProducer.java
@@ -1,0 +1,30 @@
+/*
+﻿Developed with the contribution of the European Commission - Directorate General for Maritime Affairs and Fisheries
+© European Union, 2015-2020.
+
+This file is part of the Integrated Fisheries Data Management (IFDM) Suite. The IFDM Suite is free software: you can
+redistribute it and/or modify it under the terms of the GNU General Public License as published by the
+Free Software Foundation, either version 3 of the License, or any later version. The IFDM Suite is distributed in
+the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details. You should have received a
+copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.europa.ec.fisheries.uvms.mobileterminal.rest;
+
+import javax.ejb.LocalBean;
+import javax.ejb.Stateless;
+
+import eu.europa.ec.fisheries.uvms.commons.message.impl.AbstractProducer;
+
+/**
+ * The producer bean used by the test MDBs that mock the services of other modules
+ * to respond to this module.
+ */
+@Stateless
+@LocalBean
+public class MobileTerminalModuleMockProducer extends AbstractProducer {
+	@Override
+	public String getDestinationName() {
+		return "jms/queue/UVMSMobileTerminal";
+	}
+}

--- a/rest/src/test/java/eu/europa/ec/fisheries/uvms/mobileterminal/rest/UserModuleMock.java
+++ b/rest/src/test/java/eu/europa/ec/fisheries/uvms/mobileterminal/rest/UserModuleMock.java
@@ -10,7 +10,6 @@ copy of the GNU General Public License along with the IFDM Suite. If not, see <h
  */
 package eu.europa.ec.fisheries.uvms.mobileterminal.rest;
 
-import eu.europa.ec.fisheries.uvms.commons.message.impl.AbstractProducer;
 import eu.europa.ec.fisheries.uvms.rest.security.UnionVMSFeature;
 import eu.europa.ec.fisheries.uvms.user.model.mapper.UserModuleResponseMapper;
 import eu.europa.ec.fisheries.wsdl.user.types.*;
@@ -18,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.ejb.ActivationConfigProperty;
+import javax.ejb.EJB;
 import javax.ejb.MessageDriven;
 import javax.jms.Message;
 import javax.jms.MessageListener;
@@ -31,20 +31,15 @@ public class UserModuleMock implements MessageListener {
 
     private final static Logger LOG = LoggerFactory.getLogger(UserModuleMock.class);
 
+    @EJB
+    private MobileTerminalModuleMockProducer mobileTerminalModuleMockProducer;
+
     @Override
     public void onMessage(Message message) {
         try {
             UserContext userContext = getMobileTerminalUserContext();
-            String responseString;
-            responseString = UserModuleResponseMapper.mapToGetUserContextResponse(userContext);
-
-            new AbstractProducer() {
-                @Override
-                public String getDestinationName() {
-                    return "jms/queue/UVMSMobileTerminal";
-                }
-            }.sendResponseMessageToSender((TextMessage) message, responseString);
-
+            String responseString = UserModuleResponseMapper.mapToGetUserContextResponse(userContext);
+            mobileTerminalModuleMockProducer.sendResponseMessageToSender((TextMessage) message, responseString);
         } catch (Exception e) {
             LOG.error("UserModuleMock Error", e);
         }


### PR DESCRIPTION
Deploying a real `AbstractProducer` EJB for mock responses from other modules in Arquillian tests.

The MDBs that mocked the response of other modules in Arquillian tests where creating an anonymous inner class extending the `AbstractProducer`. This worked until now but, in the context of [UNIONVMS-4656](https://github.com/UnionVMS/UVMS-UVMSCommonsLibrary/pull/148), the `AbstractProducer` requires injection of common services and the inner class `new` creation does not work. Created the `MobileTerminalModuleMockProducer` instead.